### PR TITLE
chore: add copyright and license information to Mustache templates

### DIFF
--- a/templates/demo.mustache
+++ b/templates/demo.mustache
@@ -16,6 +16,8 @@
 }}
 {{!
     @template local_corolair/demo
+    @copyright  2025 Raison
+    @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
 
     render demo page.
 

--- a/templates/embed_script.mustache
+++ b/templates/embed_script.mustache
@@ -16,6 +16,8 @@
 }}
 {{!
     @template local_corolair/embed_script
+    @copyright  2025 Raison
+    @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
 
     render student view.
 

--- a/templates/installation_troubleshoot.mustache
+++ b/templates/installation_troubleshoot.mustache
@@ -16,6 +16,8 @@
 }}
 {{!
     @template local_corolair/installation_troubleshoot
+    @copyright  2025 Raison
+    @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
 
     render the installation troubleshoot page.
 


### PR DESCRIPTION
Fixes #43
Included copyright notice for 2025 Raison and specified the GNU GPL v3 license in demo, embed_script, and installation_troubleshoot templates for compliance and clarity.