### PR TITLE
chore: update plugin version to 1.8.28 and minimum Moodle requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Raison Moodle Plugin
 
-**Version:** 1.8.23
+**Version:** 1.8.28
 
-**Last Updated:** 2025/12/18
+**Last Updated:** 2026/07/22
 
 ## Overview
 
@@ -24,6 +24,8 @@ The Raison Moodle Plugin enables seamless integration of **AI Tutors** into Mood
 ---
 
 ## Installation
+
+This plugin requires Moodle 4.4 or later.
 
 1. Install the latest version of the plugin from Moodle Plugins directory
 2. Upon installation, a Raison account with a trial plan will be automatically created for the administrator who installed the plugin.

--- a/db/services.php
+++ b/db/services.php
@@ -85,6 +85,7 @@ $services = [
             'local_corolair_manage_exam_placement',
             'core_course_delete_modules',
             'core_course_get_courses_by_field',
+            'mod_lti_toggle_showinactivitychooser',
         ],
         'restrictedusers' => 0,
         'enabled' => 1,

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 
 // Plugin metadata.
 $plugin->component = 'local_corolair';    // Full name of the plugin (used for diagnostics).
-$plugin->version   = 2026072100;          // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires  = 2020110900;          // Minimum required Moodle version.
+$plugin->version   = 2026072200;          // The current plugin version (Date: YYYYMMDDXX).
+$plugin->requires  = 2023100900;          // Minimum required Moodle version (Moodle 4.4).
 $plugin->maturity  = MATURITY_STABLE;     // Plugin maturity level: MATURITY_ALPHA, MATURITY_BETA, MATURITY_RC, MATURITY_STABLE.
-$plugin->release   = '1.8.27';             // Human-readable version name.
+$plugin->release   = '1.8.28';             // Human-readable version name.


### PR DESCRIPTION
Bumped the plugin version to 1.8.28, updated the last updated date to 2026/07/22, and specified that the plugin requires Moodle 4.4 or later. Added 'mod_lti_toggle_showinactivitychooser' to the list of external services, enhancing the plugin's functionality.