### PR TITLE
Update Raison Moodle Plugin to version 1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,78 @@
 # Raison Moodle Plugin
 
-**Version:** 1.8.29
+**Version:** 1.9.0
 
-**Last Updated:** 2026/07/27
+**Last Updated:** 2026/07/31
 
 ## Overview
 
-The Raison Moodle Plugin enables seamless integration of **AI Tutors** into Moodle courses, enhancing the learning experience for both trainers and learners. This plugin transforms courses into interactive, AI-powered learning assistants tailored to the course content.
+The Raison Moodle Plugin brings **AI Tutors** directly into Moodle. It helps trainers turn existing course content into an interactive learning experience where learners can ask questions, review key concepts, and check their understanding without leaving their course.
+
+Each AI Tutor is created and managed by a trainer or instructional designer. The tutor uses the learning resources selected for it and can be adjusted to match the course, audience, and teaching goals. Trainers remain in control of the tutor's sources and behavior.
 
 ### Key Features
 
 - **For Instructional Designers & Trainers:**
-  - Easily create and customize AI Tutors directly from Moodle courses.
-  - Curate additional resources to enhance AI Tutor responses.
-  - Monitor learner interactions and insights, including trending topics and discussion analytics.
-  - Manage AI Tutor behavior, update sources, and track usage.
+  - Create AI Tutors from Moodle courses without rebuilding course content.
+  - Select Moodle resources and add complementary material for the tutor to use.
+  - Customize each tutor's instructions, behavior, and learning purpose.
+  - Share tutors with the appropriate learners and courses.
+  - Review usage, common questions, and discussion trends to identify where learners may need more support.
 - **For Learners:**
-  - Access AI Tutors embedded natively within Moodle courses.
-  - Ask course-related questions and receive instant, AI-driven answers.
-  - Self-assess understanding using an AI-generated question bank, curated and validated by the trainer.
-  - Enjoy a flexible, stop-and-resume chatbot experience for ongoing discussions and auto-evaluation mode.
+  - Open the AI Tutor from an enrolled Moodle course.
+  - Ask questions and receive answers based on the learning material chosen by the trainer.
+  - Review a topic through a guided conversation at their own pace.
+  - Pause a discussion and return to it later.
+  - Use self-assessment activities prepared and validated by the trainer.
 
 ---
 
 ## Installation
 
-This plugin requires Moodle 4.4 or later.
+The plugin requires Moodle 3.8 or later and must be installed by a Moodle site administrator. Moodle 4.4 or later is recommended if you plan to use the Raison LTI integration, but it is not required for LTI or for the plugin's other features.
 
-1. Install the latest version of the plugin from Moodle Plugins directory
-2. Open **Site administration > Plugins > Local plugins > Raison Local Plugin** and select **Open Corolair setup**.
-3. If Moodle web services or REST are disabled, review and explicitly approve enabling them. When both are already enabled, this consent step is skipped and setup only asks you to start Corolair registration.
-4. Moodle queues the Corolair registration task. A Raison account with a trial plan is created for the administrator who started setup when that task completes successfully.
-5. Assign the _Raison Manager_ role to Trainers to configure access permissions. This role includes the capability to access Raison from Home or Courses. You can also include the corresponding capability to existing roles. Trial accounts will also be automatically set up for all assigned Trainers.
+1. Install the latest version from the Moodle Plugins directory.
+2. Go to **Site administration > Plugins > Local plugins > Raison Local Plugin** and select **Open Corolair setup**.
+3. Review the integration disclosure. It explains what the plugin can access, why that access is needed, and how information is used.
+4. If Moodle web services or REST are not already enabled, approve the required configuration changes. The plugin does not make these site-wide changes without administrator approval.
+5. Start the Raison registration. Once registration is complete, a free-trial account is created for the administrator who began the setup.
+6. Assign the _Raison Manager_ role to the trainers and instructional designers who should create and manage AI Tutors. A trial account is created automatically for each assigned trainer.
 
-The activation request requires the `moodle/site:config` capability, a POST request, and a valid Moodle session key. Existing enabled web-service protocols are preserved when REST is added. Site-wide enablement consent is requested only when Moodle web services or REST must be enabled.
+Only an authorized Moodle administrator can activate the integration. Existing Moodle web-service settings are preserved, and the setup page clearly identifies any change that requires approval.
 
-Trainer authentication redirects are accepted only when they use HTTPS, target an explicitly allowlisted Corolair hostname, and omit a port or use port 443.
+### Continuing after the free trial
 
-### Web-service token lifecycle
+If your organization chooses to continue using Raison after the free trial, continued service will require formal agreements between Raison and your organization. These agreements will define each party's responsibilities and ensure alignment on data protection, privacy, security, and applicable regulatory requirements.
 
-Corolair Moodle web-service tokens expire after 15 days. Moodle starts an automatic rotation when seven days remain and reuses the same candidate token and rotation identifier until Corolair validates and activates it. If rotation is still unresolved with five days remaining, the consenting administrator receives a rate-limited warning and can queue an immediate retry from the plugin settings. The prior token remains available only during the overlap and is then removed automatically.
+### Privacy and security
+
+During setup, administrators can review the plugin's exact access permissions, the Moodle functions it uses, and the purpose of each type of data involved. The integration uses restricted, short-lived access credentials that are renewed automatically. Trainer sign-in is limited to approved, secure Raison destinations.
+
+For questions about data processing, retention, deletion, privacy, or security, contact contact@raison.is.
 
 ---
 
 ## Access
 
-### For Trainers & Instructional Designers:
+### For Trainers & Instructional Designers
 
-- **Via Moodle Homepage:** Navigate to **Plus > Raison** to access the Creator tools.
-- **From Course View:** Select **Plus > Raison AI Assistant** to initiate the AI Tutor creation process for a specific course.
+- **From the Moodle homepage:** Go to **Plus > Raison** to open the Creator tools.
+- **From a course:** Go to **Plus > Raison AI Assistant** to create or manage an AI Tutor for that course.
 
-Once in the Creator platform, trainers can:
+In the Creator platform, trainers can:
 
 - Create, share, and monitor AI Tutors.
-- Update sources and adjust behavior.
-- Track discussions and gain insights into key learner queries.
+- Choose and update the learning sources used by a tutor.
+- Adjust tutor instructions and behavior.
+- Review discussions and identify recurring learner questions.
 
 ---
 
-### For Learners:
+### For Learners
 
-- Access Raison directly as an embedded chatbot within their enrolled courses.
-- **Start and Resume Discussions:** Click to interact with AI Tutors anytime, with the ability to pause and return.
-- **Switch Modes:** Seamlessly transition from discussion to self-assessment mode.
+- Open the Raison AI Tutor from a Moodle course where it has been made available by the trainer.
+- Start a conversation, ask questions about course content, and return to previous discussions later.
+- Move between guided discussion and self-assessment when those options are enabled by the trainer.
 
 ---
 
@@ -81,13 +91,13 @@ Once in the Creator platform, trainers can:
 
 ## Contributing
 
-We welcome contributions on the Moodle plugin! Do not hesitate to submit feature requests, bug fixes, or enhancements on [Corolair Plugin Github Repository](https://github.com/corolair/moodle-local_corolair).
+Suggestions and feedback are welcome. You can submit feature requests or report issues through the [Corolair Plugin GitHub repository](https://github.com/corolair/moodle-local_corolair).
 
 ---
 
 ## Support
 
-For support, please contact our team at contact@raison.is.
+For installation help, product questions, or technical support, contact the Raison team at contact@raison.is.
 
 ---
 

--- a/classes/local/integration_disclosure.php
+++ b/classes/local/integration_disclosure.php
@@ -29,7 +29,7 @@ namespace local_corolair\local;
  */
 final class integration_disclosure {
     /** Increment whenever the disclosed integration surface materially changes. */
-    public const VERSION = '2026-07-28-1';
+    public const VERSION = '2026-07-31-1';
 
     /**
      * Return the documented web-service groups.

--- a/lang/en/local_corolair.php
+++ b/lang/en/local_corolair.php
@@ -83,6 +83,7 @@ $string['disclosureintro'] = 'Before any web-service setting is enabled or a tok
 $string['disclosuremissing'] = 'The current integration disclosure must be acknowledged by the administrator starting setup.';
 $string['disclosureopensource'] = 'The plugin source is publicly available for security review:';
 $string['disclosureplanned'] = 'Planned use';
+$string['disclosureposttrialagreements'] = 'If your organization chooses to continue using Raison after the free trial, continued service will require formal agreements between Raison and your organization. These agreements will define each party’s responsibilities and ensure alignment on data protection, privacy, security, and applicable regulatory requirements.';
 $string['disclosureprivacycontact'] = 'For questions about external processing, retention, or deletion, contact contact@raison.is.';
 $string['disclosurepurpose'] = 'Purpose';
 $string['disclosurerole'] = 'The Raison Manager role is separate from the token. It grants local/corolair:createtutor and local/corolair:viewroles to interactive Moodle users.';

--- a/lang/es/local_corolair.php
+++ b/lang/es/local_corolair.php
@@ -83,6 +83,7 @@ $string['disclosureintro'] = 'Antes de habilitar servicios web o crear un token,
 $string['disclosuremissing'] = 'El administrador que inicia la configuración debe confirmar la versión actual de la información de integración.';
 $string['disclosureopensource'] = 'El código fuente del plugin está disponible públicamente para revisión de seguridad:';
 $string['disclosureplanned'] = 'Uso previsto';
+$string['disclosureposttrialagreements'] = 'Si su organización decide continuar utilizando Raison después del periodo de prueba gratuito, la continuidad del servicio requerirá la formalización de acuerdos entre Raison y su organización. Estos acuerdos definirán las responsabilidades de cada parte y garantizarán su alineación en materia de protección de datos, privacidad, seguridad y requisitos normativos aplicables.';
 $string['disclosureprivacycontact'] = 'Para consultas sobre tratamiento externo, conservación o eliminación, contacte con contact@raison.is.';
 $string['disclosurepurpose'] = 'Finalidad';
 $string['disclosurerole'] = 'El rol Gestor de Raison es independiente del token. Concede local/corolair:createtutor y local/corolair:viewroles a usuarios interactivos de Moodle.';

--- a/lang/fr/local_corolair.php
+++ b/lang/fr/local_corolair.php
@@ -83,6 +83,7 @@ $string['disclosureintro'] = 'Avant toute activation de service web ou création
 $string['disclosuremissing'] = 'Les informations actuelles sur l’intégration doivent être reconnues par l’administrateur qui lance la configuration.';
 $string['disclosureopensource'] = 'Le code source du plugin est disponible publiquement pour un audit de sécurité :';
 $string['disclosureplanned'] = 'Usage prévu';
+$string['disclosureposttrialagreements'] = 'Si votre organisation choisit de continuer à utiliser Raison après la période d’essai gratuite, la poursuite du service nécessitera la conclusion d’accords formels entre Raison et votre organisation. Ces accords définiront les responsabilités de chaque partie et garantiront leur alignement en matière de protection des données, de confidentialité, de sécurité et d’exigences réglementaires applicables.';
 $string['disclosureprivacycontact'] = 'Pour toute question sur le traitement externe, la conservation ou la suppression, contactez contact@raison.is.';
 $string['disclosurepurpose'] = 'Finalité';
 $string['disclosurerole'] = 'Le rôle Manager Raison est distinct du jeton. Il accorde local/corolair:createtutor et local/corolair:viewroles aux utilisateurs Moodle interactifs.';

--- a/templates/setup_disclosure.mustache
+++ b/templates/setup_disclosure.mustache
@@ -132,6 +132,9 @@
             <a href="{{repositoryurl}}" target="_blank" rel="noopener noreferrer">github.com/corolair/moodle-local_corolair</a>
         </p>
         <p>{{#str}}disclosureprivacycontact, local_corolair{{/str}}</p>
+        <div class="alert alert-info" role="note">
+            {{#str}}disclosureposttrialagreements, local_corolair{{/str}}
+        </div>
     </section>
 
     <div class="alert alert-secondary" role="note">

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 
 // Plugin metadata.
 $plugin->component = 'local_corolair';    // Full name of the plugin (used for diagnostics).
-$plugin->version   = 2026072700;          // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2026073100;          // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2023100900;          // Minimum required Moodle version (Moodle 4.4).
 $plugin->maturity  = MATURITY_STABLE;     // Plugin maturity level: MATURITY_ALPHA, MATURITY_BETA, MATURITY_RC, MATURITY_STABLE.
-$plugin->release   = '1.8.29';             // Human-readable version name.
+$plugin->release   = '1.9.0';             // Human-readable version name.


### PR DESCRIPTION
- Enhanced the README to clarify the plugin's capabilities and installation steps, including updated requirements for Moodle versions.
- Revised key features for both trainers and learners to better reflect the plugin's functionality.
- Updated integration disclosure to include post-trial agreement details, ensuring compliance with data protection and privacy standards.
- Adjusted versioning in version.php and integration_disclosure.php to reflect the new release date.
- Added new language strings for improved user guidance during setup and integration processes.